### PR TITLE
Add Spec for UUID Generation

### DIFF
--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,7 +12,13 @@ describe Order do
       it { should_not allow_mass_assignment_of :uuid }
 
       it "generates UUID before validation on_create" do
-        # TODO
+        order = Order.new.tap do |o|
+          o.name = 'marin'
+          o.user_id = 12983
+          o.price = 123.12
+        end
+        order.should_receive(:generate_uuid!)
+        order.save!
       end
 
       it { Order.primary_key.should == 'uuid' }


### PR DESCRIPTION
Test to make sure that the #generate_uuid! method is called when an
Order is created.
