### PR TITLE
Support other payment methods (Mt. Gox / Bitcoin)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (1.0.0)
+    eventmachine (1.0.0-x86-mingw32)
     execjs (1.4.0)
       multi_json (~> 1.0)
     hike (1.2.1)
@@ -65,11 +66,17 @@ GEM
     multi_json (1.3.6)
     multi_xml (0.2.2)
     pg (0.14.1)
+    pg (0.14.1-x86-mingw32)
     polyglot (0.3.3)
     pry (0.9.10)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.3.1)
+    pry (0.9.10-x86-mingw32)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
+      win32console (~> 1.3)
     pry-rails (0.2.2)
       pry (>= 0.9.10)
     rack (1.4.1)
@@ -129,6 +136,7 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.6)
+    sqlite3 (1.3.6-x86-mingw32)
     therubyracer (0.10.2)
       libv8 (~> 3.3.10)
     thin (1.5.0)
@@ -144,9 +152,11 @@ GEM
     uglifier (1.3.0)
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
+    win32console (1.3.2-x86-mingw32)
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   amazon_flex_pay

--- a/app/assets/javascripts/preorder.js.coffee
+++ b/app/assets/javascripts/preorder.js.coffee
@@ -5,10 +5,10 @@ Selfstarter =
 		# It probably should be a parser, but there isn't enough time for that (Maybe in the future though!)
 		if /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/.test($("#email").val())
 			$("#email").removeClass("highlight")
-			$("#amazon_button").removeClass("disabled")
+			$(".payment_button").removeClass("disabled")
 		else
 			$("#email").addClass("highlight") unless Selfstarter.firstTime
-			$("#amazon_button").addClass("disabled") unless $("#amazon_button").hasClass("disabled")
+			$(".payment_button").addClass("disabled") unless $(".payment_button").hasClass("disabled")
 	init: ->
 		$("#email").bind "textchange", ->
 			Selfstarter.validateEmail()

--- a/app/assets/stylesheets/checkout.css.scss
+++ b/app/assets/stylesheets/checkout.css.scss
@@ -26,7 +26,7 @@
     {
       border: 1px solid orange;
     }
-    #amazon_button
+    .payment_button
     {
       margin-top: 5px;
       padding: 15px;

--- a/app/controllers/preorder_controller.rb
+++ b/app/controllers/preorder_controller.rb
@@ -20,8 +20,11 @@ class PreorderController < ApplicationController
 		return
 	else 
 		if params[:submitMethod] == 'Checkout with Mt. Gox'
-			render :status => :internal_server_error, :text => "Mt. Gox Not Yet Supported"
-			return
+			# Register with Mt. Gox & uncomment the lines below
+			# redirect_to "https://payment.mtgox.com/099e586b-b4e6-45d1-aaf8-fbe1e44462d8"
+			# return
+			
+			render :status => :internal_server_error, :text => "Payment with Mt. Gox not yet configured"
 		end
 	end
 	render :status => :internal_server_error, :text => "Payment method not supported"
@@ -32,8 +35,8 @@ class PreorderController < ApplicationController
       @order = Order.postfill!(params)
     end
     # "A" means the user cancelled the preorder before clicking "Confirm" on Amazon Payments.
-    if params['status'] != 'A' && @order.present?
-      redirect_to :action => :share, :uuid => @order.uuid
+    if params['status'] != 'A' # && @order.present?
+      redirect_to :action => :share, :uuid => unless @order.nil? then @order.uuid else 0 end
     else
       redirect_to root_url
     end

--- a/app/helpers/preorder_helper.rb
+++ b/app/helpers/preorder_helper.rb
@@ -7,7 +7,11 @@ module PreorderHelper
     raw "<a href='http://pinterest.com/pin/create/button/?url=#{encoded_root_url}&media=#{image_url}' class='pin-it-button' count-layout='vertical'><img border='0' src='//assets.pinterest.com/images/PinExt.png' title='Pin It' /></a>"
   end
   def tweet_button
-    tweet_text = "I'm #{Settings.primary_stat_verb} number #{number_with_delimiter @order.number, :delimiter => ","} #{Settings.tweet_text}!"
+    if @order
+		tweet_text = "I'm #{Settings.primary_stat_verb} number #{number_with_delimiter @order.number, :delimiter => ","} #{Settings.tweet_text} #{Settings.product_name}!"
+	else
+		tweet_text = "I'm backing #{Settings.tweet_text} #{Settings.product_name}!"
+	end
     raw "<a href='https://twitter.com/share?url=/' id='tweet_button' class='twitter-share-button twitter-button' data-url=#{request.scheme}//#{request.host}' data-via='#{Settings.product_name}' data-lang='en' data-count='vertical' data-text=\"#{tweet_text}\">Tweet</a>"
   end
 

--- a/app/views/preorder/checkout.html.erb
+++ b/app/views/preorder/checkout.html.erb
@@ -19,7 +19,7 @@
 		
 		<!-- Pay in Bitcoin with Mt. Gox -->
 		<!-- Uncomment the following to allow paying via Mt. Gox -->
-		<!-- <%= submit_tag "Checkout with Mt. Gox", :class => "blue_button disabled payment_button", :id => "mtgox_button", :name => "submitMethod" %> -->
+		<%= submit_tag "Checkout with Mt. Gox", :class => "blue_button disabled payment_button", :id => "mtgox_button", :name => "submitMethod" %>
       <% end %>
 	  	  
     </div>

--- a/app/views/preorder/checkout.html.erb
+++ b/app/views/preorder/checkout.html.erb
@@ -6,14 +6,22 @@
         Let your backers know how their payment information will be handled.
         <br />
         <br />
-        Enter your email address below.
+        aEnter your email address below.
       </p>
+	  
       <%= form_tag "/preorder/prefill", :id => "checkout" do %>
         <%= email_field_tag "email", nil, :placeholder => "hello@lockitron.com", :required => "required", :id => "email" %>
         <%= hidden_field_tag "preorder", true %>
         <%= hidden_field_tag "quantity", params[:quantity] %>
-        <%= submit_tag "Checkout", :class => "blue_button disabled", :id => "amazon_button" %>
+		
+		<!-- Default Amazon Checkout -->
+        <%= submit_tag "Checkout with Amazon", :class => "blue_button disabled payment_button", :id => "amazon_button", :name => "submitMethod" %>
+		
+		<!-- Pay in Bitcoin with Mt. Gox -->
+		<!-- Uncomment the following to allow paying via Mt. Gox -->
+		<!-- <%= submit_tag "Checkout with Mt. Gox", :class => "blue_button disabled payment_button", :id => "mtgox_button", :name => "submitMethod" %> -->
       <% end %>
+	  	  
     </div>
     <%= render 'preorder/checkout/sidebar' %>
   </div>

--- a/app/views/preorder/checkout.html.erb
+++ b/app/views/preorder/checkout.html.erb
@@ -19,7 +19,7 @@
 		
 		<!-- Pay in Bitcoin with Mt. Gox -->
 		<!-- Uncomment the following to allow paying via Mt. Gox -->
-		<%= submit_tag "Checkout with Mt. Gox", :class => "blue_button disabled payment_button", :id => "mtgox_button", :name => "submitMethod" %>
+		<!-- <%= submit_tag "Checkout with Mt. Gox", :class => "blue_button disabled payment_button", :id => "mtgox_button", :name => "submitMethod" %> -->
       <% end %>
 	  	  
     </div>

--- a/app/views/preorder/share.html.erb
+++ b/app/views/preorder/share.html.erb
@@ -3,7 +3,11 @@
     <h2>
       Hooray! You've just reserved a <%= Settings.product_name %>!
     </h2>
-    <p>Congratulations, you're <%= Settings.primary_stat_verb %> number <span id="backer_number"><%= number_with_delimiter @order.number, :delimiter => "," %></span>,  in supporting <%= Settings.product_name %>. Share the great news!</p>
+    <% if @order %>
+		<p>Congratulations, you're <%= Settings.primary_stat_verb %> number <span id="backer_number"><%= number_with_delimiter @order.number, :delimiter => "," %></span>,  in supporting <%= Settings.product_name %>. Share the great news!</p>
+	<% else %>
+		<p>Congratulations, you're a backer - thanks for supporting <%= Settings.product_name %>. Share the great news!</p>
+	<% end %>
     <br />
     <br />
     <div id="share" class="clearfix">
@@ -17,7 +21,9 @@
         <%= like_button(450, true) %>
       </div>
     </div>
-     <div id="order_id">Reservation ID: <%= @order.uuid %>. You can bookmark or print this page for your records.</div>
+	<% if @order %>
+      <div id="order_id">Reservation ID: <%= @order.uuid %>. You can bookmark or print this page for your records.</div>
+	<% end %>
   </div>
 </div>
 


### PR DESCRIPTION
It seems that Amazon Money transfer services are currently only available in the United States.
I've added support for Bitcoin (off by default).

This pull request contains:
1. [Small code changes to make the payment method generic](https://github.com/commerce-sciences/selfstarter/commit/ffc4268c3e8f29306eb414a0132c5a68b6b6c5c6)
2. Adding Mt. Gox as a payment method

To enable it, you need to:
1. Understand what Bitcoins are (http://bitcoin.org/ and http://weusecoins.com/ are a good start)
2. Register for an Mt. Gox merchant account at http://mtgox.com/
3. Create a Checkout Button via Mt. Gox
4. Copy the Payment URL into preorder_controller
5. Uncomment the Mt. Gox submit button in app/views/preorder/checkout.html.erb
