### PR TITLE
Annotate models + Order scope bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rails', '3.2.11'
 group :development do
   gem 'sqlite3'
   gem 'pry-rails'
+  gem 'annotate', ">=2.5.0"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
       activesupport (>= 3.0.14)
       multi_xml (~> 0.2.0)
       rest-client (~> 1.6.1)
+    annotate (2.5.0)
+      rake
     arel (3.0.2)
     bourne (1.1.2)
       mocha (= 0.10.5)
@@ -154,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   amazon_flex_pay
+  annotate (>= 2.5.0)
   coffee-rails (~> 3.2.1)
   jquery-rails
   pg

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: orders
+#
+#  token             :string(255)
+#  transaction_id    :string(255)
+#  address_one       :string(255)
+#  address_two       :string(255)
+#  city              :string(255)
+#  state             :string(255)
+#  zip               :string(255)
+#  country           :string(255)
+#  status            :string(255)
+#  number            :string(255)
+#  uuid              :string(255)      primary key
+#  user_id           :string(255)
+#  price             :decimal(, )
+#  shipping          :decimal(, )
+#  tracking_number   :string(255)
+#  phone             :string(255)
+#  name              :string(255)
+#  expiration        :date
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  payment_option_id :integer
+#
+
 class Order < ActiveRecord::Base
   attr_accessible :address_one, :address_two, :city, :country, :number, :state, :status, :token, :transaction_id, :zip,
                   :shipping, :tracking_number, :name, :price, :phone, :expiration, :payment_option

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -32,7 +32,7 @@ class Order < ActiveRecord::Base
   before_validation :generate_uuid!, :on => :create
   belongs_to :user
   belongs_to :payment_option
-  scope :completed, where("token != ? OR token != ?", "", nil)
+  scope :completed, where("token != ? OR token IS NOT NULL", "")
   self.primary_key = 'uuid'
 
   # This is where we create our Caller Reference for Amazon Payments, and prefill some other information.

--- a/app/models/payment_option.rb
+++ b/app/models/payment_option.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: payment_options
+#
+#  id             :integer          not null, primary key
+#  amount         :decimal(, )
+#  amount_display :string(255)
+#  description    :text
+#  shipping_desc  :string(255)
+#  delivery_desc  :string(255)
+#  limit          :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
 class PaymentOption < ActiveRecord::Base
   attr_accessible :amount, :amount_display, :delivery_desc, :description, :limit, :shipping_desc
   has_many :orders

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  email      :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 class User < ActiveRecord::Base
   attr_accessible :email
   has_many :orders

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: orders
+#
+#  token             :string(255)
+#  transaction_id    :string(255)
+#  address_one       :string(255)
+#  address_two       :string(255)
+#  city              :string(255)
+#  state             :string(255)
+#  zip               :string(255)
+#  country           :string(255)
+#  status            :string(255)
+#  number            :string(255)
+#  uuid              :string(255)      primary key
+#  user_id           :string(255)
+#  price             :decimal(, )
+#  shipping          :decimal(, )
+#  tracking_number   :string(255)
+#  phone             :string(255)
+#  name              :string(255)
+#  expiration        :date
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  payment_option_id :integer
+#
+
 describe Order do
 
   context "attributes" do

--- a/spec/models/payment_option_spec.rb
+++ b/spec/models/payment_option_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: payment_options
+#
+#  id             :integer          not null, primary key
+#  amount         :decimal(, )
+#  amount_display :string(255)
+#  description    :text
+#  shipping_desc  :string(255)
+#  delivery_desc  :string(255)
+#  limit          :integer
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
 require 'spec_helper'
 
 describe PaymentOption do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  email      :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 describe User do
 
   it { should have_many :orders }


### PR DESCRIPTION
This Pull Request serves two purposes
### Adding [Annotate Models](https://github.com/ctran/annotate_models)

In the code base, all models and specs have their attributes and corresponding datatypes in the form of comments. This makes development for developers easier by serving as a visual cue.
### Fixed a Bug in the order completed scope

Prior to this, the Order.completed scope was returning the following SQL.

``` sql
   SELECT "orders".* FROM "orders" WHERE (token != '' OR token != NULL)
```

The SQL is incorrect because logical operations on NULL will always result in a NULL. i.e. (NULL = NULL would yield a NULL). It has now been fixed to 

``` sql
   SELECT "orders".* FROM "orders" WHERE (token != '' OR token IS NOT NULL)
```
