### PR TITLE
AmazonFlexPay usage broke, so I fixed it

### DIFF
--- a/app/controllers/preorder_controller.rb
+++ b/app/controllers/preorder_controller.rb
@@ -24,15 +24,13 @@ class PreorderController < ApplicationController
     # This is where all the magic happens. We create a multi-use token with Amazon, letting us charge the user's Amazon account
     # Then, if they confirm the payment, Amazon POSTs us their shipping details and phone number
     # From there, we save it, and voila, we got ourselves a preorder!
-    @pipeline = AmazonFlexPay.multi_use_pipeline(@order.uuid,
+    port = Rails.env.production? ? "" : ":3000"
+    callback_url = "#{request.scheme}://#{request.host}#{port}/preorder/postfill"
+    redirect_to AmazonFlexPay.multi_use_pipeline(@order.uuid, callback_url,
                                                  :transaction_amount => price,
                                                  :global_amount_limit => price + Settings.charge_limit,
                                                  :collect_shipping_address => "True",
                                                  :payment_reason => Settings.payment_description)
-
-
-    port = Rails.env.production? ? "" : ":3000"
-    redirect_to @pipeline.url("#{request.scheme}://#{request.host}#{port}/preorder/postfill")
   end
 
   def postfill


### PR DESCRIPTION
At one point, it seems that AmazonFlexPay returned an object on which you could call `#url`. It doesn't do that anymore (https://github.com/kickstarter/amazon_flex_pay/commit/512d077b563c573122a43392e875752ca78b4e86). It returns the url as a String. So, method_not_found errors (calling `String#url`) were a-flyin'. I updated the call to `AmazonFlexPay.multi_use_pipeline`, which you can now `redirect_to` directly, and removed the `@pipeline` and `@pipeline.url` business altogether.
