### PR TITLE
Errors during rake db:migrate 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ end
 # jQuery
 gem 'jquery-rails'
 
+gem 'execjs'
+gem 'therubyracer'
+
 # Kickstarter's awesome Amazon Flexible Payments gem
 gem 'amazon_flex_pay'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.7.6)
+    libv8 (3.11.8.13)
     mail (2.4.4)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -103,6 +104,7 @@ GEM
     rake (10.0.3)
     rdoc (3.12)
       json (~> 1.4)
+    ref (1.0.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec-core (2.12.2)
@@ -135,6 +137,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.6)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -155,6 +160,7 @@ PLATFORMS
 DEPENDENCIES
   amazon_flex_pay
   coffee-rails (~> 3.2.1)
+  execjs
   jquery-rails
   pg
   pry-rails
@@ -164,5 +170,6 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   shoulda
   sqlite3
+  therubyracer
   thin
   uglifier (>= 1.0.3)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Selfstarter::Application.config.session_store :cookie_store, key: '_Selfstarter_session'
+Selfstarter::Application.config.session_store :cookie_store, :key => '_Selfstarter_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters :format => [:json]
 end
 
 # Disable root element in JSON by default.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.


### PR DESCRIPTION
I experienced some errors during the `rake db:migrate`, I think it had something to do with ruby backwards compatibility between 1.8.7 and 1.9.2.
