### PR TITLE
Update Global Limit for AmazonFlexPay

### DIFF
--- a/app/controllers/preorder_controller.rb
+++ b/app/controllers/preorder_controller.rb
@@ -28,7 +28,7 @@ class PreorderController < ApplicationController
     callback_url = "#{request.scheme}://#{request.host}#{port}/preorder/postfill"
     redirect_to AmazonFlexPay.multi_use_pipeline(@order.uuid, callback_url,
                                                  :transaction_amount => price,
-                                                 :global_amount_limit => price + Settings.charge_limit,
+                                                 :global_amount_limit => Settings.charge_limit,
                                                  :collect_shipping_address => "True",
                                                  :payment_reason => Settings.payment_description)
   end


### PR DESCRIPTION
In the `app/controllers/preorder_controller.rb` the global_amount_limit was set to `price+Settings.charge_limit` but this would be too high, `settings.yaml` asks for a limit so this change is simply to set the `global_amount_limit` to `Settings.charge_limit`
