### PR TITLE
subscribe email address to mailchimp list on checkout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,6 @@ gem 'amazon_flex_pay'
 
 # Configuration File
 gem 'rails_config'
+
+# Mailchimp
+gem 'mailchimp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     hike (1.2.1)
+    httparty (0.11.0)
+      multi_json (~> 1.0)
+      multi_xml (>= 0.5.2)
     i18n (0.6.1)
     journey (1.0.4)
     jquery-rails (2.1.4)
@@ -61,6 +64,8 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    mailchimp (0.0.9)
+      httparty
     metaclass (0.0.1)
     method_source (0.8.1)
     mime-types (1.22)
@@ -157,6 +162,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   jquery-rails
   json (~> 1.7.7)
+  mailchimp
   pg
   pry-rails
   rails (= 3.2.13)

--- a/app/controllers/preorder_controller.rb
+++ b/app/controllers/preorder_controller.rb
@@ -1,3 +1,5 @@
+require 'mailchimp'
+
 class PreorderController < ApplicationController
   skip_before_filter :verify_authenticity_token, :only => :ipn
 
@@ -9,6 +11,12 @@ class PreorderController < ApplicationController
 
   def prefill
     @user  = User.find_or_create_by_email!(params[:email])
+
+    if Settings.use_mailchimp
+      api = Mailchimp::API.new(Settings.mailchimp_api_key)
+      # you may want other options set here, see http://apidocs.mailchimp.com/api/
+      success = api.listSubscribe(id: Settings.mailchimp_list_id, email_address: params[:email])
+    end
 
     if Settings.use_payment_options
       payment_option_id = params['payment_option']

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,6 +55,12 @@ payment_description: "You really should change this text because people will see
 # this value will be added to the price to create a charge limit
 charge_limit: 25.00
 
+# Mailchimp settings -- only if you want to integrate with Mailchimp
+
+use_mailchimp: false
+mailchimp_api_key: "YOUR_MAILCHIMP_API_KEY"
+mailchimp_list_id: "YOUR_MAILCHIMP_LIST_ID"
+
 # Stats settings
 
 # On Lockitron, it's "backers"


### PR DESCRIPTION
Allows selfstarters to automatically subscribe e-mail address gathered at checkout into a Mailchimp list.
